### PR TITLE
Add dim, blink and hidden

### DIFF
--- a/ansi-styles.js
+++ b/ansi-styles.js
@@ -5,9 +5,12 @@ var codes = {
 	reset: [0, 0],
 
 	bold: [1, 22],
+	dim: [ 2, 22 ],
 	italic: [3, 23],
 	underline: [4, 24],
+	blink: [ 5, 25 ],
 	inverse: [7, 27],
+	hidden: [ 8, 28 ],
 	strikethrough: [9, 29],
 
 	black: [30, 39],


### PR DESCRIPTION
dim, blink and hidden are supported by some terminals: http://misc.flogisoft.com/bash/tip_colors_and_formatting

Specifically, I want them because tmux supports them and I want to write something that maps tmux color codes to ansi color codes, using ansi-styles for the lookup
