### PR TITLE
Group related codes into categories

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,37 +4,56 @@ var styles = module.exports;
 var codes = {
 	reset: [0, 0],
 
-	bold: [1, 22], // 21 isn't widely supported and 22 does the same thing
-	dim: [2, 22],
-	italic: [3, 23],
-	underline: [4, 24],
-	inverse: [7, 27],
-	hidden: [8, 28],
-	strikethrough: [9, 29],
+	modifiers: {
+		bold: [1, 22], // 21 isn't widely supported and 22 does the same thing
+		dim: [2, 22],
+		italic: [3, 23],
+		underline: [4, 24],
+		inverse: [7, 27],
+		hidden: [8, 28],
+		strikethrough: [9, 29]
+	},
 
-	black: [30, 39],
-	red: [31, 39],
-	green: [32, 39],
-	yellow: [33, 39],
-	blue: [34, 39],
-	magenta: [35, 39],
-	cyan: [36, 39],
-	white: [37, 39],
-	gray: [90, 39],
+	colors: {
+		black: [30, 39],
+		red: [31, 39],
+		green: [32, 39],
+		yellow: [33, 39],
+		blue: [34, 39],
+		magenta: [35, 39],
+		cyan: [36, 39],
+		white: [37, 39],
+		gray: [90, 39]
+	},
 
-	bgBlack: [40, 49],
-	bgRed: [41, 49],
-	bgGreen: [42, 49],
-	bgYellow: [43, 49],
-	bgBlue: [44, 49],
-	bgMagenta: [45, 49],
-	bgCyan: [46, 49],
-	bgWhite: [47, 49]
+	bgColors: {
+		bgBlack: [40, 49],
+		bgRed: [41, 49],
+		bgGreen: [42, 49],
+		bgYellow: [43, 49],
+		bgBlue: [44, 49],
+		bgMagenta: [45, 49],
+		bgCyan: [46, 49],
+		bgWhite: [47, 49]
+	}
+};
+
+var makeStyle = function (code) {
+	return {
+		open: '\u001b[' + code[0] + 'm',
+		close: '\u001b[' + code[1] + 'm'
+	};
 };
 
 Object.keys(codes).forEach(function (key) {
 	var val = codes[key];
-	var style = styles[key] = {};
-	style.open = '\u001b[' + val[0] + 'm';
-	style.close = '\u001b[' + val[1] + 'm';
+	if (typeof val == 'object') {
+		var group = styles[key] = {};
+		Object.keys(val).forEach(function (key) {
+			styles[key] = group[key] = makeStyle(val[key]);
+		});
+	}
+	else {
+		styles[key] = makeStyle(val);
+	}
 });

--- a/test.js
+++ b/test.js
@@ -23,4 +23,10 @@ describe('ansiStyles()', function () {
 		assert.equal(ansi.bgGreen.open, '\x1b[42m');
 		assert.equal(ansi.green.close, '\x1b[39m');
 	});
+
+	it('should group related codes into categories', function () {
+		assert.equal(ansi.colors.magenta, ansi.magenta);
+		assert.equal(ansi.bgColors.bgYellow, ansi.bgYellow);
+		assert.equal(ansi.modifiers.bold, ansi.bold);
+	});
 });


### PR DESCRIPTION
This patch groups all colors together in `ansi.colors`, all modifiers in `ansi.modifiers`, and all background colors in `ansi.bgColors`. The individual values still remain in their original locations, but new shortcuts emerge: `ansi.green == ansi.colors.green`.

It finally makes it possible to iterate over all available colors or modifiers.
