### PR TITLE
add 256/16m color support

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,31 @@
 'use strict';
+var colorConvert = require('color-convert');
+
+function wrapAnsi16(fn, offset) {
+	return function () {
+		var code = fn.apply(colorConvert, arguments);
+		return '\u001b[' + (code + offset) + 'm';
+	};
+}
+
+function wrapAnsi256(fn, offset) {
+	return function () {
+		var code = fn.apply(colorConvert, arguments);
+		return '\u001b[' + (38 + offset) + ';5;' + code + 'm';
+	};
+}
+
+function wrapAnsi16m(fn, offset) {
+	return function () {
+		var rgb = fn.apply(colorConvert, arguments);
+		return '\u001b[' + (38 + offset) + ';2;' +
+			rgb[0] + ';' + rgb[1] + ';' + rgb[2] + 'm';
+	};
+}
 
 function assembleStyles() {
 	var styles = {
-		modifiers: {
+		modifier: {
 			reset: [0, 0],
 			// 21 isn't widely supported and 22 does the same thing
 			bold: [1, 22],
@@ -13,7 +36,7 @@ function assembleStyles() {
 			hidden: [8, 28],
 			strikethrough: [9, 29]
 		},
-		colors: {
+		color: {
 			black: [30, 39],
 			red: [31, 39],
 			green: [32, 39],
@@ -24,7 +47,7 @@ function assembleStyles() {
 			white: [37, 39],
 			gray: [90, 39]
 		},
-		bgColors: {
+		bgColor: {
 			bgBlack: [40, 49],
 			bgRed: [41, 49],
 			bgGreen: [42, 49],
@@ -37,7 +60,7 @@ function assembleStyles() {
 	};
 
 	// fix humans
-	styles.colors.grey = styles.colors.gray;
+	styles.color.grey = styles.color.gray;
 
 	Object.keys(styles).forEach(function (groupName) {
 		var group = styles[groupName];
@@ -56,6 +79,48 @@ function assembleStyles() {
 			enumerable: false
 		});
 	});
+
+	function rgb2rgb(r, g, b) {
+		return [r, g, b];
+	}
+
+	styles.color.close = '\u001b[39m';
+	styles.bgColor.close = '\u001b[49m';
+
+	styles.color.ansi = {};
+	styles.color.ansi256 = {};
+	styles.color.ansi16m = {
+		rgb: wrapAnsi16m(rgb2rgb, 0)
+	};
+
+	styles.bgColor.ansi = {};
+	styles.bgColor.ansi256 = {};
+	styles.bgColor.ansi16m = {
+		rgb: wrapAnsi16m(rgb2rgb, 10)
+	};
+
+	for (var key in colorConvert) {
+		if (!colorConvert.hasOwnProperty(key) || typeof colorConvert[key] !== 'object') {
+			continue;
+		}
+
+		var suite = colorConvert[key];
+
+		if ('ansi16' in suite) {
+			styles.color.ansi[key] = wrapAnsi16(suite.ansi16, 0);
+			styles.bgColor.ansi[key] = wrapAnsi16(suite.ansi16, 10);
+		}
+
+		if ('ansi' in suite) {
+			styles.color.ansi256[key] = wrapAnsi256(suite.ansi, 0);
+			styles.bgColor.ansi256[key] = wrapAnsi256(suite.ansi, 10);
+		}
+
+		if ('rgb' in suite) {
+			styles.color.ansi16m[key] = wrapAnsi16m(suite.rgb, 0);
+			styles.bgColor.ansi16m[key] = wrapAnsi16m(suite.rgb, 10);
+		}
+	}
 
 	return styles;
 }

--- a/package.json
+++ b/package.json
@@ -45,6 +45,9 @@
     "command-line",
     "text"
   ],
+  "dependencies": {
+    "color-convert": "^0.7.0"
+  },
   "devDependencies": {
     "ava": "*",
     "xo": "*"

--- a/readme.md
+++ b/readme.md
@@ -17,11 +17,19 @@ $ npm install --save ansi-styles
 ## Usage
 
 ```js
-const ansi = require('ansi-styles');
+const style = require('ansi-styles');
 
-console.log(ansi.green.open + 'Hello world!' + ansi.green.close);
+console.log(style.green.open + 'Hello world!' + style.green.close);
+
+// color conversion between 16/256/truecolor
+// NOTE: if conversion goes to 16 colors or 256 colors, the original color
+//       may be degraded to fit that color palette. This means terminals
+//       that do not support 16 million colors will best-match the
+//       original color.
+console.log(style.bgColor.ansi.hsl(120, 80, 72) + 'Hello world!' + style.bgColor.close);
+console.log(style.color.ansi256.rgb(199, 20, 250) + 'Hello world!' + style.color.close);
+console.log(style.color.ansi16m.hex('#ABCDEF') + 'Hello world!' + style.color.close);
 ```
-
 
 ## API
 
@@ -69,17 +77,32 @@ Each style has an `open` and `close` property.
 
 By default you get a map of styles, but the styles are also available as groups. They are non-enumerable so they don't show up unless you access them explicitly. This makes it easier to expose only a subset in a higher-level module.
 
-- `ansi.modifiers`
-- `ansi.colors`
-- `ansi.bgColors`
+- `style.modifier`
+- `style.color`
+- `style.bgColor`
 
 
 ###### Example
 
 ```js
-console.log(ansi.colors.green.open);
+console.log(style.color.green.open);
 ```
 
+## [256 / 16 million (TrueColor) support](https://gist.github.com/XVilka/8346728)
+`ansi-styles` uses the [`color-convert`](https://github.com/MoOx/color-convert) package to allow for converting between various colors and ANSI escapes, with support for 256 and 16 million colors.
+
+To use these, call the associated conversion function with the intended output, e.g.:
+
+```js
+style.color.ansi.rgb(100, 200, 15); // RGB to 16 color ansi foreground code
+style.bgColor.ansi.rgb(100, 200, 15); // RGB to 16 color ansi background code
+
+style.color.ansi256.hsl(120, 100, 60); // HSL to 256 color ansi foreground code
+style.bgColor.ansi256.hsl(120, 100, 60); // HSL to 256 color ansi foreground code
+
+style.color.ansi16m.hex('#C0FFEE'); // Hex (RGB) to 16 million color foreground code
+style.bgColor.ansi16m.hex('#C0FFEE'); // Hex (RGB) to 16 million color background code
+```
 
 ## Related
 

--- a/test.js
+++ b/test.js
@@ -1,36 +1,37 @@
 import test from 'ava';
-import ansi from './';
+import style from './';
 
 // generates the screenshot
-for (const [key, val] of Object.entries(ansi)) {
-	let style = val.open;
+for (const [key, val] of Object.entries(style)) {
+	let code = val.open;
 
 	if (key === 'reset' || key === 'hidden') {
 		continue;
 	}
 
 	if (/^bg[^B]/.test(key)) {
-		style = ansi.black.open + style;
+		code = style.black.open + code;
 	}
 
-	process.stdout.write(style + key + ansi.reset.close + ' ');
+	process.stdout.write(code + key + style.reset.close + ' ');
 }
 
 test('return ANSI escape codes', t => {
-	t.is(ansi.green.open, '\u001b[32m');
-	t.is(ansi.bgGreen.open, '\u001b[42m');
-	t.is(ansi.green.close, '\u001b[39m');
-	t.is(ansi.gray.open, ansi.grey.open);
+	t.is(style.green.open, '\u001b[32m');
+	t.is(style.bgGreen.open, '\u001b[42m');
+	t.is(style.green.close, '\u001b[39m');
+	t.is(style.gray.open, style.grey.open);
 });
 
 test('group related codes into categories', t => {
-	t.is(ansi.colors.magenta, ansi.magenta);
-	t.is(ansi.bgColors.bgYellow, ansi.bgYellow);
-	t.is(ansi.modifiers.bold, ansi.bold);
+	t.is(style.color.magenta, style.magenta);
+	t.is(style.bgColor.bgYellow, style.bgYellow);
+	t.is(style.modifier.bold, style.bold);
 });
 
 test('groups should not be enumerable', t => {
-	t.true(Object.keys(ansi).indexOf('modifiers') === -1);
+	t.true(Object.getOwnPropertyDescriptor(style, 'modifier') !== undefined);
+	t.true(Object.keys(style).indexOf('modifier') === -1);
 });
 
 test('don\'t pollute other objects', t => {
@@ -38,4 +39,45 @@ test('don\'t pollute other objects', t => {
 	const obj2 = require('./');
 	obj1.foo = true;
 	t.not(obj1.foo, obj2.foo);
+});
+
+test('support conversion to ansi (16 colors)', t => {
+	t.is(style.color.ansi.rgb(255, 255, 255), '\u001b[97m');
+	t.is(style.color.ansi.hsl(140, 100, 50), '\u001b[92m');
+	t.is(style.color.ansi.hex('#990099'), '\u001b[35m');
+	t.is(style.color.ansi.hex('#FF00FF'), '\u001b[95m');
+
+	t.is(style.bgColor.ansi.rgb(255, 255, 255), '\u001b[107m');
+	t.is(style.bgColor.ansi.hsl(140, 100, 50), '\u001b[102m');
+	t.is(style.bgColor.ansi.hex('#990099'), '\u001b[45m');
+	t.is(style.bgColor.ansi.hex('#FF00FF'), '\u001b[105m');
+});
+
+test('support conversion to ansi (256 colors)', t => {
+	t.is(style.color.ansi256.rgb(255, 255, 255), '\u001b[38;5;231m');
+	t.is(style.color.ansi256.hsl(140, 100, 50), '\u001b[38;5;48m');
+	t.is(style.color.ansi256.hex('#990099'), '\u001b[38;5;127m');
+	t.is(style.color.ansi256.hex('#FF00FF'), '\u001b[38;5;201m');
+
+	t.is(style.bgColor.ansi256.rgb(255, 255, 255), '\u001b[48;5;231m');
+	t.is(style.bgColor.ansi256.hsl(140, 100, 50), '\u001b[48;5;48m');
+	t.is(style.bgColor.ansi256.hex('#990099'), '\u001b[48;5;127m');
+	t.is(style.bgColor.ansi256.hex('#FF00FF'), '\u001b[48;5;201m');
+});
+
+test('support conversion to ansi (16 million colors)', t => {
+	t.is(style.color.ansi16m.rgb(255, 255, 255), '\u001b[38;2;255;255;255m');
+	t.is(style.color.ansi16m.hsl(140, 100, 50), '\u001b[38;2;0;255;85m');
+	t.is(style.color.ansi16m.hex('#990099'), '\u001b[38;2;153;0;153m');
+	t.is(style.color.ansi16m.hex('#FF00FF'), '\u001b[38;2;255;0;255m');
+
+	t.is(style.bgColor.ansi16m.rgb(255, 255, 255), '\u001b[48;2;255;255;255m');
+	t.is(style.bgColor.ansi16m.hsl(140, 100, 50), '\u001b[48;2;0;255;85m');
+	t.is(style.bgColor.ansi16m.hex('#990099'), '\u001b[48;2;153;0;153m');
+	t.is(style.bgColor.ansi16m.hex('#FF00FF'), '\u001b[48;2;255;0;255m');
+});
+
+test('16/256/16m color close escapes', t => {
+	t.is(style.color.close, '\u001b[39m');
+	t.is(style.bgColor.close, '\u001b[49m');
 });


### PR DESCRIPTION
In reference to #11.

Here it is. It adds two new properties, `color` and `bgColor`. Both properties each have three properties, `ansi16`, `ansi256`, and `ansi16m`. These properties each expose all of the [ANSI conversions available from `color-convert`](https://github.com/harthur/color-convert/blob/master/conversions.js#L69-L81).

Tests are inbound (waiting on high-level feedback).