### PR TITLE
Add function syntax for styles

### DIFF
--- a/index.js
+++ b/index.js
@@ -86,8 +86,8 @@ function assembleStyles() {
 				close: `\u001B[${style[1]}m`
 			};
 
-			styles[styleName] = () => {
-				return tags.open + [].slice.call(arguments).join(' ') + tags.close};
+			styles[styleName] = function () {
+				return tags.open + [].slice.call(arguments).join(' ') + tags.close;
 			};
 
 			styles[styleName].open = tags.open;

--- a/index.js
+++ b/index.js
@@ -81,17 +81,17 @@ function assembleStyles() {
 		for (const styleName of Object.keys(group)) {
 			const style = group[styleName];
 
-			let tags = {
+			const tags = {
 				open: `\u001B[${style[0]}m`,
 				close: `\u001B[${style[1]}m`
 			};
 
-			styles[styleName] = (...str) => {
-				return `${tags.open}${str.join(' ')}${tags.close}`
-			}
+			styles[styleName] = () => {
+				return tags.open + [].slice.call(arguments).join(' ') + tags.close};
+			};
 
-			styles[styleName].open = tags.open
-			styles[styleName].close = tags.close
+			styles[styleName].open = tags.open;
+			styles[styleName].close = tags.close;
 
 			group[styleName] = styles[styleName];
 

--- a/index.js
+++ b/index.js
@@ -81,10 +81,17 @@ function assembleStyles() {
 		for (const styleName of Object.keys(group)) {
 			const style = group[styleName];
 
-			styles[styleName] = {
+			let tags = {
 				open: `\u001B[${style[0]}m`,
 				close: `\u001B[${style[1]}m`
 			};
+
+			styles[styleName] = (...str) => {
+				return `${tags.open}${str.join(' ')}${tags.close}`
+			}
+
+			styles[styleName].open = tags.open
+			styles[styleName].close = tags.close
 
 			group[styleName] = styles[styleName];
 

--- a/readme.md
+++ b/readme.md
@@ -19,7 +19,15 @@ $ npm install ansi-styles
 ```js
 const style = require('ansi-styles');
 
+// Property syntax:
 console.log(`${style.green.open}Hello world!${style.green.close}`);
+
+// Function syntax:
+console.log(style.green('Hello world!'));
+
+// You can stack them as well!
+console.log(`${style.green.open}${style.bold.open}Hello world!${style.bold.close}${style.green.close}`);
+console.log(style.green(style.bold('Hello world!')));
 
 
 // Color conversion between 16/256/truecolor
@@ -34,7 +42,7 @@ console.log(style.color.ansi16m.hex('#ABCDEF') + 'Hello world!' + style.color.cl
 
 ## API
 
-Each style has an `open` and `close` property.
+Each style is a function that takes infinite number of arguments, also `open` and `close` properties to style strings manually.
 
 
 ## Styles

--- a/readme.md
+++ b/readme.md
@@ -25,7 +25,7 @@ console.log(`${style.green.open}Hello world!${style.green.close}`);
 // Function syntax:
 console.log(style.green('Hello world!'));
 
-// You can stack them as well!
+// You can nest them as well!
 console.log(`${style.green.open}${style.bold.open}Hello world!${style.bold.close}${style.green.close}`);
 console.log(style.green(style.bold('Hello world!')));
 


### PR DESCRIPTION
This PR brings a function syntax for styling strings while having backwards compatibility for `open` and `close` tags. So instead of `${ansi.red.open} string ${ansi.red.close}`, one can now use it like `ansi.red('string')` which is way easier in most situations. Next step is to chain style tags like `ansi.red.bold('string')`.