### PR TITLE
Fix a bug in `chalk` when `supports-color` gives level 2

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,6 +17,7 @@ const wrapAnsi16m = (fn, offset) => function () {
 };
 
 function assembleStyles() {
+	const codes = new Map();
 	const styles = {
 		modifier: {
 			reset: [0, 0],
@@ -86,10 +87,17 @@ function assembleStyles() {
 			};
 
 			group[styleName] = styles[styleName];
+
+			codes.set(style[0], style[1]);
 		}
 
 		Object.defineProperty(styles, groupName, {
 			value: group,
+			enumerable: false
+		});
+
+		Object.defineProperty(styles, 'codes', {
+			value: codes,
 			enumerable: false
 		});
 	}

--- a/index.js
+++ b/index.js
@@ -102,19 +102,24 @@ function assembleStyles() {
 		});
 	}
 
+	const ansi2ansi = n => n;
 	const rgb2rgb = (r, g, b) => [r, g, b];
 
 	styles.color.close = '\u001B[39m';
 	styles.bgColor.close = '\u001B[49m';
 
 	styles.color.ansi = {};
-	styles.color.ansi256 = {};
+	styles.color.ansi256 = {
+		ansi256: wrapAnsi256(ansi2ansi, 0)
+	};
 	styles.color.ansi16m = {
 		rgb: wrapAnsi16m(rgb2rgb, 0)
 	};
 
 	styles.bgColor.ansi = {};
-	styles.bgColor.ansi256 = {};
+	styles.bgColor.ansi256 = {
+		ansi256: wrapAnsi256(ansi2ansi, 10)
+	};
 	styles.bgColor.ansi16m = {
 		rgb: wrapAnsi16m(rgb2rgb, 10)
 	};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ansi-styles",
-	"version": "3.1.0",
+	"version": "3.2.0",
 	"description": "ANSI escape codes for styling strings in the terminal",
 	"license": "MIT",
 	"repository": "chalk/ansi-styles",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
 		"text"
 	],
 	"dependencies": {
-		"color-convert": "^1.9.0"
+		"color-convert": "^1.9.0",
+		"resolve-from": "^4.0.0"
 	},
 	"devDependencies": {
 		"ava": "*",

--- a/readme.md
+++ b/readme.md
@@ -60,8 +60,7 @@ Each style has an `open` and `close` property.
 - `magenta`
 - `cyan`
 - `white`
-- `gray`
-- `blackBright`
+- `gray` ("bright black")
 - `redBright`
 - `greenBright`
 - `yellowBright`

--- a/readme.md
+++ b/readme.md
@@ -88,6 +88,7 @@ Each style has an `open` and `close` property.
 - `bgCyanBright`
 - `bgWhiteBright`
 
+
 ## Advanced usage
 
 By default, you get a map of styles, but the styles are also available as groups. They are non-enumerable so they don't show up unless you access them explicitly. This makes it easier to expose only a subset in a higher-level module.
@@ -100,6 +101,15 @@ By default, you get a map of styles, but the styles are also available as groups
 
 ```js
 console.log(style.color.green.open);
+```
+
+Raw escape codes (i.e. without the CSI escape prefix `\u001B[` and render mode postfix `m`) are available under `style.codes`, which returns a `Map` with the open codes as keys and close codes as values.
+
+###### Example
+
+```js
+console.log(style.codes.get(36));
+//=> 39
 ```
 
 

--- a/test.js
+++ b/test.js
@@ -82,3 +82,11 @@ test('16/256/16m color close escapes', t => {
 	t.is(style.color.close, '\u001B[39m');
 	t.is(style.bgColor.close, '\u001B[49m');
 });
+
+test('export raw ANSI escape codes', t => {
+	t.is(style.codes.get(0), 0);
+	t.is(style.codes.get(1), 22);
+	t.is(style.codes.get(91), 39);
+	t.is(style.codes.get(40), 49);
+	t.is(style.codes.get(100), 49);
+});

--- a/test/test.js
+++ b/test/test.js
@@ -3,7 +3,7 @@ import test from 'ava';
 // Spoof supports color
 require('./_supports-color')(__dirname);
 
-import style from '.';
+const style = require( '..' );
 
 // Generates the screenshot
 for (const [key, val] of Object.entries(style)) {
@@ -39,21 +39,21 @@ test('groups should not be enumerable', t => {
 });
 
 test('don\'t pollute other objects', t => {
-	const obj1 = require('.');
-	const obj2 = require('.');
+	const obj1 = require('..');
+	const obj2 = require('..');
 
 	obj1.foo = true;
 	t.not(obj1.foo, obj2.foo);
 });
 
 test('all color types are always available', t => {
-	const ansi = style.color.ansi
-	const ansi256 = style.color.ansi256
-	const ansi16m = style.color.ansi16m
+	const ansi = style.color.ansi;
+	const ansi256 = style.color.ansi256;
+	const ansi16m = style.color.ansi16m;
 
-	t.true(ansi    && ansi.ansi    && ansi.ansi256    && ansi.ansi16m)
-	t.true(ansi256 && ansi256.ansi && ansi256.ansi256 && ansi256.ansi16m)
-	t.true(ansi16m && ansi16m.ansi && ansi16m.ansi256 && ansi16m.ansi16m)
+	t.true(ansi && ansi.ansi && ansi.ansi256 && ansi.ansi16m);
+	t.true(ansi256 && ansi256.ansi && ansi256.ansi256 && ansi256.ansi16m);
+	t.true(ansi16m && ansi16m.ansi && ansi16m.ansi256 && ansi16m.ansi16m);
 });
 
 test('support conversion to ansi (16 colors)', t => {

--- a/test/test.js
+++ b/test/test.js
@@ -3,7 +3,7 @@ import test from 'ava';
 // Spoof supports color
 require('./_supports-color')(__dirname);
 
-const style = require( '..' );
+const style = require('..');
 
 // Generates the screenshot
 for (const [key, val] of Object.entries(style)) {


### PR DESCRIPTION
The bug seems mainly apparent on Windows systems. (See https://github.com/chalk/chalk/issues/224)