### PR TITLE
Improve error messages for `keyword()` method

### DIFF
--- a/index.js
+++ b/index.js
@@ -103,24 +103,46 @@ function assembleStyles() {
 	}
 
 	const rgb2rgb = (r, g, b) => [r, g, b];
+	const keyword2rgb = keyword => {
+		const rgb = colorConvert.keyword.rgb(keyword);
+		if (!rgb) {
+			throw new Error(`Invalid arguments provided to keyword: ${keyword}`);
+		}
+		return rgb;
+	};
+	const keyword2ansi = keyword => colorConvert.rgb.ansi16(keyword2rgb(keyword));
+	const keyword2ansi256 = keyword => colorConvert.rgb.ansi256(keyword2rgb(keyword));
 
 	styles.color.close = '\u001B[39m';
 	styles.bgColor.close = '\u001B[49m';
 
-	styles.color.ansi = {};
-	styles.color.ansi256 = {};
+	styles.color.ansi = {
+		keyword: wrapAnsi16(keyword2ansi, 0)
+	};
+	styles.color.ansi256 = {
+		keyword: wrapAnsi256(keyword2ansi256, 0)
+	};
 	styles.color.ansi16m = {
+		keyword: wrapAnsi16m(keyword2rgb, 0),
 		rgb: wrapAnsi16m(rgb2rgb, 0)
 	};
 
-	styles.bgColor.ansi = {};
-	styles.bgColor.ansi256 = {};
+	styles.bgColor.ansi = {
+		keyword: wrapAnsi16(keyword2ansi, 10)
+	};
+	styles.bgColor.ansi256 = {
+		keyword: wrapAnsi256(keyword2ansi256, 10)
+	};
 	styles.bgColor.ansi16m = {
+		keyword: wrapAnsi16m(keyword2rgb, 10),
 		rgb: wrapAnsi16m(rgb2rgb, 10)
 	};
 
 	for (const key of Object.keys(colorConvert)) {
 		if (typeof colorConvert[key] !== 'object') {
+			continue;
+		}
+		if (key === 'keyword') {
 			continue;
 		}
 

--- a/test.js
+++ b/test.js
@@ -78,6 +78,18 @@ test('support conversion to ansi (16 million colors)', t => {
 	t.is(style.bgColor.ansi16m.hex('#FF00FF'), '\u001B[48;2;255;0;255m');
 });
 
+test('supports css keywords', t => {
+	t.is(style.color.ansi.keyword('red'), '\u001B[91m');
+	t.is(style.color.ansi256.keyword('red'), '\u001B[38;5;196m');
+	t.is(style.color.ansi16m.keyword('red'), '\u001B[38;2;255;0;0m');
+});
+
+test('throw meaningful error for invalid css keywords', t => {
+	t.throws(() => style.color.ansi.keyword('qwerty'), 'Invalid arguments provided to keyword: qwerty');
+	t.throws(() => style.color.ansi256.keyword('qwerty'), 'Invalid arguments provided to keyword: qwerty');
+	t.throws(() => style.color.ansi16m.keyword('qwerty'), 'Invalid arguments provided to keyword: qwerty');
+});
+
 test('16/256/16m color close escapes', t => {
 	t.is(style.color.close, '\u001B[39m');
 	t.is(style.bgColor.close, '\u001B[49m');


### PR DESCRIPTION
Alternate implementation for fixing #36 based off of conversation from #41 

Fixes #36 