### PR TITLE
Avoid redefining the `codes` property for every group

### DIFF
--- a/index.js
+++ b/index.js
@@ -135,12 +135,12 @@ function assembleStyles() {
 			value: group,
 			enumerable: false
 		});
-
-		Object.defineProperty(styles, 'codes', {
-			value: codes,
-			enumerable: false
-		});
 	}
+
+	Object.defineProperty(styles, 'codes', {
+		value: codes,
+		enumerable: false
+	});
 
 	styles.color.close = '\u001B[39m';
 	styles.bgColor.close = '\u001B[49m';


### PR DESCRIPTION
Previously, the `codes` property would be set with `Object.defineProperty` for every iteration.

This makes it so that it’s only ever set once.