### PR TITLE
Specify @types/color-name as a dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,11 +44,11 @@
 		"text"
 	],
 	"dependencies": {
-		"@types/color-name": "^1.1.1",
 		"color-convert": "^2.0.1"
 	},
 	"devDependencies": {
 		"@types/color-convert": "^1.9.0",
+		"@types/color-name": "^1.1.1",
 		"ava": "^2.3.0",
 		"svg-term-cli": "^2.1.1",
 		"tsd": "^0.11.0",


### PR DESCRIPTION
A ground-breaking change, I know. While cleaning up dependencies I noticed this in a prod build. Was this specified as a non-dev dependency for a reason? `npm test` and `require('.')` both passed fine.

Thanks for your time. 