### PR TITLE
Remove named capture group

### DIFF
--- a/index.js
+++ b/index.js
@@ -134,7 +134,7 @@ function assembleStyles() {
 					return [0, 0, 0];
 				}
 
-				let colorString = matches[0];
+				let [colorString] = matches;
 
 				if (colorString.length === 3) {
 					colorString = colorString.split('').map(character => character + character).join('');

--- a/index.js
+++ b/index.js
@@ -129,12 +129,12 @@ function assembleStyles() {
 		},
 		hexToRgb: {
 			value: hex => {
-				const matches = /(?<colorString>[a-f\d]{6}|[a-f\d]{3})/i.exec(hex.toString(16));
+				const matches = /[a-f\d]{6}|[a-f\d]{3}/i.exec(hex.toString(16));
 				if (!matches) {
 					return [0, 0, 0];
 				}
 
-				let {colorString} = matches.groups;
+				let colorString = matches[0];
 
 				if (colorString.length === 3) {
 					colorString = colorString.split('').map(character => character + character).join('');


### PR DESCRIPTION
Follow up to #78 with the requested change. Also fixes #76

It makes sense not wanting to add workarounds for random engines (like hermes). However, I would argue that this is not a workaround. Instead it makes the code easier to read and more performant. There is no real reason to use named capture groups here.