### PR TITLE
Fixhot webpack reg exp

### DIFF
--- a/index.js
+++ b/index.js
@@ -129,7 +129,7 @@ function assembleStyles() {
 		},
 		hexToRgb: {
 			value: hex => {
-				const matches = /(?<colorString>[a-f\d]{6}|[a-f\d]{3})/i.exec(hex.toString(16));
+				const matches = new RegExp('(?<colorString>[a-f\\d]{6}|[a-f\\d]{3})', 'i').exec(hex.toString(16));
 				if (!matches) {
 					return [0, 0, 0];
 				}

--- a/package.json
+++ b/package.json
@@ -19,6 +19,14 @@
 		"test": "xo && ava && tsd",
 		"screenshot": "svg-term --command='node screenshot' --out=screenshot.svg --padding=3 --width=55 --height=3 --at=1000 --no-cursor"
 	},
+	"xo": {
+		"space": true,
+		"rules": {
+			"prefer-regex-literals": "off",
+			"indent": "off",
+			"@typescript-eslint/indent": "off"
+		}
+	},
 	"files": [
 		"index.js",
 		"index.d.ts"


### PR DESCRIPTION
# Problem
Error reporting with webpack package，
<img width="916" alt="image" src="https://user-images.githubusercontent.com/45714422/157588756-9e089423-dbf6-4fd0-a59f-6e62613666e8.png">
# Solution
1. Regexp constructor replaces regular expression text.
2. Regexp constructor caused eslint problem, and I closed the corresponding rules

# Environment
- webpack version: 3.12.0
- VS Code Version: 1.65
- OS Version: macOS big sur 11.4
- OS chip: Apple M1
- node Version: 14.16.1
