### PR TITLE
Expose style names

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -187,18 +187,21 @@ export type ModifierName = keyof Modifier;
 
 /**
 Basic foreground color names.
+
 [More colors here.](https://github.com/chalk/chalk/blob/main/readme.md#256-and-truecolor-color-support)
 */
 export type ForegroundColorName = keyof ForegroundColor;
 
 /**
 Basic background color names.
+
 [More colors here.](https://github.com/chalk/chalk/blob/main/readme.md#256-and-truecolor-color-support)
 */
 export type BackgroundColorName = keyof BackgroundColor;
 
 /**
 Basic color names. The combination of foreground and background color names.
+
 [More colors here.](https://github.com/chalk/chalk/blob/main/readme.md#256-and-truecolor-color-support)
 */
 export type ColorName = ForegroundColorName | BackgroundColorName;

--- a/index.d.ts
+++ b/index.d.ts
@@ -187,4 +187,9 @@ declare const ansiStyles: {
 	readonly codes: ReadonlyMap<number, number>;
 } & ForegroundColor & BackgroundColor & Modifier & ConvertColor;
 
+declare const modifiers: readonly Modifier[];
+declare const foregroundColors: readonly ForegroundColor[];
+declare const backgroundColors: readonly BackgroundColor[];
+declare const colors: readonly Color[];
+
 export default ansiStyles;

--- a/index.d.ts
+++ b/index.d.ts
@@ -132,8 +132,6 @@ export interface BackgroundColor {
 	readonly bgWhiteBright: CSPair;
 }
 
-export type Color = (ForegroundColor | BackgroundColor);
-
 export interface ConvertColor {
 	/**
 	Convert from the RGB color space to the ANSI 256 color space.
@@ -182,6 +180,43 @@ export interface ConvertColor {
 	hexToAnsi(hex: string): number;
 }
 
+/**
+Basic modifiers.
+*/
+export type ModifierName =
+	| 'reset'
+	| 'bold'
+	| 'dim'
+	| 'italic'
+	| 'underline'
+	| 'overline'
+	| 'inverse'
+	| 'hidden'
+	| 'strikethrough'
+	| 'visible';
+
+type BasicColor = 'black' | 'red' | 'green' | 'yellow' | 'blue' | 'magenta' | 'cyan' | 'white';
+type BrightColor = `${BasicColor}Bright`;
+type Grey = 'gray' | 'grey';
+
+/**
+Basic foreground colors.
+[More colors here.](https://github.com/chalk/chalk/blob/main/readme.md#256-and-truecolor-color-support)
+*/
+export type ForegroundColorName = BasicColor | BrightColor | Grey;
+
+/**
+Basic background colors.
+[More colors here.](https://github.com/chalk/chalk/blob/main/readme.md#256-and-truecolor-color-support)
+*/
+export type BackgroundColorName = `bg${Capitalize<ForegroundColorName>}`;
+
+/**
+Basic colors. The combination of foreground and background color names.
+[More colors here.](https://github.com/chalk/chalk/blob/main/readme.md#256-and-truecolor-color-support)
+*/
+export type ColorName = ForegroundColor | BackgroundColor;
+
 declare const ansiStyles: {
 	readonly modifier: Modifier;
 	readonly color: ColorBase & ForegroundColor;
@@ -189,9 +224,24 @@ declare const ansiStyles: {
 	readonly codes: ReadonlyMap<number, number>;
 } & ForegroundColor & BackgroundColor & Modifier & ConvertColor;
 
-declare const modifiers: readonly Modifier[];
-declare const foregroundColors: readonly ForegroundColor[];
-declare const backgroundColors: readonly BackgroundColor[];
-declare const colors: readonly Color[];
+/**
+Basic modifier names.
+*/
+declare const modifierNames: readonly ModifierName[];
+
+/**
+Basic foreground color names.
+*/
+declare const foregroundColorNames: readonly ForegroundColorName[];
+
+/**
+Basic background color names.
+*/
+declare const backgroundColorNames: readonly BackgroundColorName[];
+
+/*
+Basic color names. The combination of foreground and background color names.
+*/
+declare const colorNames: readonly ColorName[];
 
 export default ansiStyles;

--- a/index.d.ts
+++ b/index.d.ts
@@ -132,6 +132,8 @@ export interface BackgroundColor {
 	readonly bgWhiteBright: CSPair;
 }
 
+export type Color = (ForegroundColor | BackgroundColor);
+
 export interface ConvertColor {
 	/**
 	Convert from the RGB color space to the ANSI 256 color space.

--- a/index.d.ts
+++ b/index.d.ts
@@ -183,39 +183,25 @@ export interface ConvertColor {
 /**
 Basic modifiers.
 */
-export type ModifierName =
-	| 'reset'
-	| 'bold'
-	| 'dim'
-	| 'italic'
-	| 'underline'
-	| 'overline'
-	| 'inverse'
-	| 'hidden'
-	| 'strikethrough'
-	| 'visible';
-
-type BasicColor = 'black' | 'red' | 'green' | 'yellow' | 'blue' | 'magenta' | 'cyan' | 'white';
-type BrightColor = `${BasicColor}Bright`;
-type Grey = 'gray' | 'grey';
+export type ModifierName = keyof Modifier;
 
 /**
 Basic foreground colors.
 [More colors here.](https://github.com/chalk/chalk/blob/main/readme.md#256-and-truecolor-color-support)
 */
-export type ForegroundColorName = BasicColor | BrightColor | Grey;
+export type ForegroundColorName = keyof ForegroundColor;
 
 /**
 Basic background colors.
 [More colors here.](https://github.com/chalk/chalk/blob/main/readme.md#256-and-truecolor-color-support)
 */
-export type BackgroundColorName = `bg${Capitalize<ForegroundColorName>}`;
+export type BackgroundColorName = keyof BackgroundColor;
 
 /**
 Basic colors. The combination of foreground and background color names.
 [More colors here.](https://github.com/chalk/chalk/blob/main/readme.md#256-and-truecolor-color-support)
 */
-export type ColorName = ForegroundColor | BackgroundColor;
+export type ColorName = ForegroundColorName | BackgroundColorName;
 
 /**
 Basic modifier names.

--- a/index.d.ts
+++ b/index.d.ts
@@ -217,31 +217,31 @@ Basic colors. The combination of foreground and background color names.
 */
 export type ColorName = ForegroundColor | BackgroundColor;
 
+/**
+Basic modifier names.
+*/
+export const modifierNames: readonly ModifierName[];
+
+/**
+Basic foreground color names.
+*/
+export const foregroundColorNames: readonly ForegroundColorName[];
+
+/**
+Basic background color names.
+*/
+export const backgroundColorNames: readonly BackgroundColorName[];
+
+/*
+Basic color names. The combination of foreground and background color names.
+*/
+export const colorNames: readonly ColorName[];
+
 declare const ansiStyles: {
 	readonly modifier: Modifier;
 	readonly color: ColorBase & ForegroundColor;
 	readonly bgColor: ColorBase & BackgroundColor;
 	readonly codes: ReadonlyMap<number, number>;
 } & ForegroundColor & BackgroundColor & Modifier & ConvertColor;
-
-/**
-Basic modifier names.
-*/
-declare const modifierNames: readonly ModifierName[];
-
-/**
-Basic foreground color names.
-*/
-declare const foregroundColorNames: readonly ForegroundColorName[];
-
-/**
-Basic background color names.
-*/
-declare const backgroundColorNames: readonly BackgroundColorName[];
-
-/*
-Basic color names. The combination of foreground and background color names.
-*/
-declare const colorNames: readonly ColorName[];
 
 export default ansiStyles;

--- a/index.d.ts
+++ b/index.d.ts
@@ -181,24 +181,24 @@ export interface ConvertColor {
 }
 
 /**
-Basic modifiers.
+Basic modifier names.
 */
 export type ModifierName = keyof Modifier;
 
 /**
-Basic foreground colors.
+Basic foreground color names.
 [More colors here.](https://github.com/chalk/chalk/blob/main/readme.md#256-and-truecolor-color-support)
 */
 export type ForegroundColorName = keyof ForegroundColor;
 
 /**
-Basic background colors.
+Basic background color names.
 [More colors here.](https://github.com/chalk/chalk/blob/main/readme.md#256-and-truecolor-color-support)
 */
 export type BackgroundColorName = keyof BackgroundColor;
 
 /**
-Basic colors. The combination of foreground and background color names.
+Basic color names. The combination of foreground and background color names.
 [More colors here.](https://github.com/chalk/chalk/blob/main/readme.md#256-and-truecolor-color-support)
 */
 export type ColorName = ForegroundColorName | BackgroundColorName;

--- a/index.js
+++ b/index.js
@@ -214,9 +214,10 @@ function assembleStyles() {
 }
 
 const ansiStyles = assembleStyles();
+
+export default ansiStyles;
+
 export const modifierNames = Object.keys(styles.modifier);
 export const foregroundColorNames = Object.keys(styles.color);
 export const backgroundColorNames = Object.keys(styles.bgColor);
 export const colorNames = [...foregroundColorNames, ...backgroundColorNames];
-
-export default ansiStyles;

--- a/index.js
+++ b/index.js
@@ -214,9 +214,9 @@ function assembleStyles() {
 }
 
 const ansiStyles = assembleStyles();
-export const modifiers = Object.keys(styles.modifier);
-export const foregroundColors = Object.keys(styles.color);
-export const backgroundColors = Object.keys(styles.bgColor);
-export const colors = [...foregroundColors, ...backgroundColors];
+export const modifierNames = Object.keys(styles.modifier);
+export const foregroundColorNames = Object.keys(styles.color);
+export const backgroundColorNames = Object.keys(styles.bgColor);
+export const colorNames = [...foregroundColorNames, ...backgroundColorNames];
 
 export default ansiStyles;

--- a/index.js
+++ b/index.js
@@ -217,5 +217,6 @@ const ansiStyles = assembleStyles();
 export const modifiers = Object.keys(styles.modifier);
 export const foregroundColors = Object.keys(styles.color);
 export const backgroundColors = Object.keys(styles.bgColor);
+export const colors = [...foregroundColors, ...backgroundColors];
 
 export default ansiStyles;

--- a/index.js
+++ b/index.js
@@ -6,68 +6,67 @@ const wrapAnsi256 = (offset = 0) => code => `\u001B[${38 + offset};5;${code}m`;
 
 const wrapAnsi16m = (offset = 0) => (red, green, blue) => `\u001B[${38 + offset};2;${red};${green};${blue}m`;
 
+const styles = {
+	modifier: {
+		reset: [0, 0],
+		// 21 isn't widely supported and 22 does the same thing
+		bold: [1, 22],
+		dim: [2, 22],
+		italic: [3, 23],
+		underline: [4, 24],
+		overline: [53, 55],
+		inverse: [7, 27],
+		hidden: [8, 28],
+		strikethrough: [9, 29],
+	},
+	color: {
+		black: [30, 39],
+		red: [31, 39],
+		green: [32, 39],
+		yellow: [33, 39],
+		blue: [34, 39],
+		magenta: [35, 39],
+		cyan: [36, 39],
+		white: [37, 39],
+
+		// Bright color
+		blackBright: [90, 39],
+		gray: [90, 39], // Alias of `blackBright`
+		grey: [90, 39], // Alias of `blackBright`
+		redBright: [91, 39],
+		greenBright: [92, 39],
+		yellowBright: [93, 39],
+		blueBright: [94, 39],
+		magentaBright: [95, 39],
+		cyanBright: [96, 39],
+		whiteBright: [97, 39],
+	},
+	bgColor: {
+		bgBlack: [40, 49],
+		bgRed: [41, 49],
+		bgGreen: [42, 49],
+		bgYellow: [43, 49],
+		bgBlue: [44, 49],
+		bgMagenta: [45, 49],
+		bgCyan: [46, 49],
+		bgWhite: [47, 49],
+
+		// Bright color
+		bgBlackBright: [100, 49],
+		bgGray: [100, 49], // Alias of `bgBlackBright`
+		bgGrey: [100, 49], // Alias of `bgBlackBright`
+		bgRedBright: [101, 49],
+		bgGreenBright: [102, 49],
+		bgYellowBright: [103, 49],
+		bgBlueBright: [104, 49],
+		bgMagentaBright: [105, 49],
+		bgCyanBright: [106, 49],
+		bgWhiteBright: [107, 49],
+	},
+};
+
 function assembleStyles() {
 	const codes = new Map();
-	const styles = {
-		modifier: {
-			reset: [0, 0],
-			// 21 isn't widely supported and 22 does the same thing
-			bold: [1, 22],
-			dim: [2, 22],
-			italic: [3, 23],
-			underline: [4, 24],
-			overline: [53, 55],
-			inverse: [7, 27],
-			hidden: [8, 28],
-			strikethrough: [9, 29],
-		},
-		color: {
-			black: [30, 39],
-			red: [31, 39],
-			green: [32, 39],
-			yellow: [33, 39],
-			blue: [34, 39],
-			magenta: [35, 39],
-			cyan: [36, 39],
-			white: [37, 39],
-
-			// Bright color
-			blackBright: [90, 39],
-			redBright: [91, 39],
-			greenBright: [92, 39],
-			yellowBright: [93, 39],
-			blueBright: [94, 39],
-			magentaBright: [95, 39],
-			cyanBright: [96, 39],
-			whiteBright: [97, 39],
-		},
-		bgColor: {
-			bgBlack: [40, 49],
-			bgRed: [41, 49],
-			bgGreen: [42, 49],
-			bgYellow: [43, 49],
-			bgBlue: [44, 49],
-			bgMagenta: [45, 49],
-			bgCyan: [46, 49],
-			bgWhite: [47, 49],
-
-			// Bright color
-			bgBlackBright: [100, 49],
-			bgRedBright: [101, 49],
-			bgGreenBright: [102, 49],
-			bgYellowBright: [103, 49],
-			bgBlueBright: [104, 49],
-			bgMagentaBright: [105, 49],
-			bgCyanBright: [106, 49],
-			bgWhiteBright: [107, 49],
-		},
-	};
-
-	// Alias bright black as gray (and grey)
-	styles.color.gray = styles.color.blackBright;
-	styles.bgColor.bgGray = styles.bgColor.bgBlackBright;
-	styles.color.grey = styles.color.blackBright;
-	styles.bgColor.bgGrey = styles.bgColor.bgBlackBright;
 
 	for (const [groupName, group] of Object.entries(styles)) {
 		for (const [styleName, style] of Object.entries(group)) {
@@ -215,5 +214,8 @@ function assembleStyles() {
 }
 
 const ansiStyles = assembleStyles();
+export const modifiers = Object.keys(styles.modifier);
+export const foregroundColors = Object.keys(styles.color);
+export const backgroundColors = Object.keys(styles.bgColor);
 
 export default ansiStyles;

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,5 +1,5 @@
-import {expectType} from 'tsd';
-import ansiStyles, {CSPair} from './index.js';
+import {expectError, expectType} from 'tsd';
+import ansiStyles, {CSPair, ModifierName, ForegroundColorName, BackgroundColorName, ColorName} from './index.js';
 
 expectType<ReadonlyMap<number, number>>(ansiStyles.codes);
 
@@ -118,3 +118,21 @@ expectType<CSPair>(ansiStyles.italic);
 expectType<CSPair>(ansiStyles.reset);
 expectType<CSPair>(ansiStyles.strikethrough);
 expectType<CSPair>(ansiStyles.underline);
+
+// --- ModifierName ---
+expectType<ModifierName>('strikethrough');
+expectError<ModifierName>('delete');
+
+// --- ForegroundColorName ---
+expectType<ForegroundColorName>('blue');
+expectError<ForegroundColorName>('pink');
+
+// --- ForegroundColorName ---
+expectType<BackgroundColorName>('bgBlue');
+expectError<BackgroundColorName>('bgPink');
+
+// --- ColorName ---
+expectType<ColorName>('blue');
+expectType<ColorName>('bgBlue');
+expectError<ColorName>('pink');
+expectError<ColorName>('bgPink');

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,4 +1,4 @@
-import {expectError, expectType} from 'tsd';
+import {expectAssignable, expectError, expectType} from 'tsd';
 import ansiStyles, {CSPair, ModifierName, ForegroundColorName, BackgroundColorName, ColorName} from './index.js';
 
 expectType<ReadonlyMap<number, number>>(ansiStyles.codes);
@@ -120,19 +120,19 @@ expectType<CSPair>(ansiStyles.strikethrough);
 expectType<CSPair>(ansiStyles.underline);
 
 // --- ModifierName ---
-expectType<ModifierName>('strikethrough');
+expectAssignable<ModifierName>('strikethrough');
 expectError<ModifierName>('delete');
 
 // --- ForegroundColorName ---
-expectType<ForegroundColorName>('blue');
+expectAssignable<ForegroundColorName>('blue');
 expectError<ForegroundColorName>('pink');
 
 // --- ForegroundColorName ---
-expectType<BackgroundColorName>('bgBlue');
+expectAssignable<BackgroundColorName>('bgBlue');
 expectError<BackgroundColorName>('bgPink');
 
 // --- ColorName ---
-expectType<ColorName>('blue');
-expectType<ColorName>('bgBlue');
+expectAssignable<ColorName>('blue');
+expectAssignable<ColorName>('bgBlue');
 expectError<ColorName>('pink');
 expectError<ColorName>('bgPink');

--- a/readme.md
+++ b/readme.md
@@ -32,7 +32,25 @@ console.log(`${styles.color.ansi16m(...styles.hexToRgb('#abcdef'))}Hello World${
 
 ## API
 
+### `open` and `close`
+
 Each style has an `open` and `close` property.
+
+### modifiers, foregroundColors, backgroundColors, and colors
+
+All supported style strings are exposed as an array of strings for convenience. `colors` is the combination of `foregroundColors` and `backgroundColors`.
+
+This can be useful if you wrap Chalk and need to validate input:
+
+```js
+import {modifiers, foregroundColors} from 'ansi-styles';
+
+console.log(modifiers.includes('bold'));
+//=> true
+
+console.log(foregroundColors.includes('pink'));
+//=> false
+```
 
 ## Styles
 

--- a/readme.md
+++ b/readme.md
@@ -36,7 +36,7 @@ console.log(`${styles.color.ansi16m(...styles.hexToRgb('#abcdef'))}Hello World${
 
 Each style has an `open` and `close` property.
 
-### modifiers, foregroundColors, backgroundColors, and colors
+### `modifiers`, `foregroundColors`, `backgroundColors`, and `colors`
 
 All supported style strings are exposed as an array of strings for convenience. `colors` is the combination of `foregroundColors` and `backgroundColors`.
 

--- a/readme.md
+++ b/readme.md
@@ -36,11 +36,11 @@ console.log(`${styles.color.ansi16m(...styles.hexToRgb('#abcdef'))}Hello World${
 
 Each style has an `open` and `close` property.
 
-### `modifiers`, `foregroundColors`, `backgroundColors`, and `colors`
+### `modifierNames`, `foregroundColorNames`, `backgroundColorNames`, and `colorNames`
 
-All supported style strings are exposed as an array of strings for convenience. `colors` is the combination of `foregroundColors` and `backgroundColors`.
+All supported style strings are exposed as an array of strings for convenience. `colorNames` is the combination of `foregroundColorNames` and `backgroundColorNames`.
 
-This can be useful if you wrap Chalk and need to validate input:
+This can be useful if you need to validate input:
 
 ```js
 import {modifiers, foregroundColors} from 'ansi-styles';

--- a/readme.md
+++ b/readme.md
@@ -43,12 +43,12 @@ All supported style strings are exposed as an array of strings for convenience. 
 This can be useful if you need to validate input:
 
 ```js
-import {modifiers, foregroundColors} from 'ansi-styles';
+import {modifierNames, foregroundColorNames} from 'ansi-styles';
 
-console.log(modifiers.includes('bold'));
+console.log(modifierNames.includes('bold'));
 //=> true
 
-console.log(foregroundColors.includes('pink'));
+console.log(foregroundColorNames.includes('pink'));
 //=> false
 ```
 


### PR DESCRIPTION
Related to https://github.com/chalk/chalk/pull/566 and https://github.com/chalk/chalk/pull/567. 

### Changes

- Move aliases definitions to the literal
- Export style names